### PR TITLE
feat: add dprint code formatter with treefmt integration

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -100,6 +100,7 @@
         inherit
           (treefmtEvalPlatform.config.build.programs)
           alejandra # nix formatter
+          dprint # code formatter
           shellcheck # sh linter
           shfmt # sh formatter
           statix # nix linter

--- a/treefmt.nix
+++ b/treefmt.nix
@@ -2,6 +2,49 @@ _: {
   projectRootFile = ".git/config";
   programs = {
     alejandra.enable = true;
+    dprint = {
+      enable = true;
+      settings = {
+        incremental = true;
+        lineWidth = 80;
+        indentWidth = 2;
+        useTabs = false;
+        newLineKind = "lf";
+        typescript = {
+          semiColons = "asi";
+          quoteStyle = "alwaysSingle";
+          "jsx.quoteStyle" = "preferSingle";
+          quoteProps = "asNeeded";
+          useBraces = "preferNone";
+          singleBodyPosition = "sameLine";
+          "arrowFunction.useParentheses" = "preferNone";
+          "typeLiteral.separatorKind" = "comma";
+        };
+        json.trailingCommas = "never";
+        markdown.textWrap = "always";
+        markup.quotes = "single";
+        ruff.lineLength = 80;
+        includes = [
+          "**/*.{astro,html,ts,tsx,js,mjs,cjs,jsx,json,jsonc,toml,yaml,yml,md}"
+          "**/*.{graphql,gql,ipynb,py,pyi}"
+          "Dockerfile"
+        ];
+        excludes = ["node_modules" "*-lock.json" "*-lock.yaml" "dist"];
+        # https://plugins.dprint.dev
+        plugins = [
+          "https://plugins.dprint.dev/typescript-0.93.0.wasm"
+          "https://plugins.dprint.dev/json-0.19.3.wasm"
+          "https://plugins.dprint.dev/markdown-0.17.8.wasm"
+          "https://plugins.dprint.dev/toml-0.6.2.wasm"
+          "https://plugins.dprint.dev/dockerfile-0.3.2.wasm"
+          "https://plugins.dprint.dev/ruff-0.3.9.wasm"
+          "https://plugins.dprint.dev/jupyter-0.1.4.wasm"
+          "https://plugins.dprint.dev/g-plane/markup_fmt-v0.12.0.wasm"
+          "https://plugins.dprint.dev/g-plane/pretty_yaml-v0.5.0.wasm"
+          "https://plugins.dprint.dev/g-plane/pretty_graphql-v0.2.0.wasm"
+        ];
+      };
+    };
     statix.enable = true;
     shellcheck.enable = true;
     shfmt.enable = true;

--- a/treefmt.nix
+++ b/treefmt.nix
@@ -1,48 +1,21 @@
-_: {
+{pkgs, ...}: {
   projectRootFile = ".git/config";
   programs = {
     alejandra.enable = true;
     dprint = {
       enable = true;
-      includes = [
-        "**/*.{astro,html,ts,tsx,js,mjs,cjs,jsx,json,jsonc,toml,yaml,yml,md}"
-        "**/*.{graphql,gql,ipynb,py,pyi}"
-        "Dockerfile"
-      ];
-      excludes = ["node_modules" "*-lock.json" "*-lock.yaml" "dist"];
+      includes = ["**/*.md"];
       settings = {
         incremental = true;
         lineWidth = 80;
         indentWidth = 2;
         useTabs = false;
         newLineKind = "lf";
-        typescript = {
-          semiColons = "asi";
-          quoteStyle = "alwaysSingle";
-          "jsx.quoteStyle" = "preferSingle";
-          quoteProps = "asNeeded";
-          useBraces = "preferNone";
-          singleBodyPosition = "sameLine";
-          "arrowFunction.useParentheses" = "preferNone";
-          "typeLiteral.separatorKind" = "comma";
-        };
-        json.trailingCommas = "never";
         markdown.textWrap = "always";
-        markup.quotes = "single";
-        ruff.lineLength = 80;
         # https://plugins.dprint.dev
-        plugins = [
-          "https://plugins.dprint.dev/typescript-0.95.5.wasm"
-          "https://plugins.dprint.dev/json-0.20.0.wasm"
-          "https://plugins.dprint.dev/markdown-0.18.0.wasm"
-          "https://plugins.dprint.dev/toml-0.7.0.wasm"
-          "https://plugins.dprint.dev/dockerfile-0.3.3.wasm"
-          "https://plugins.dprint.dev/ruff-0.3.9.wasm"
-          "https://plugins.dprint.dev/jupyter-0.2.0.wasm"
-          "https://plugins.dprint.dev/g-plane/markup_fmt-v0.20.0.wasm"
-          "https://plugins.dprint.dev/g-plane/pretty_yaml-v0.5.1.wasm"
-          "https://plugins.dprint.dev/g-plane/pretty_graphql-v0.2.1.wasm"
-        ];
+        plugins = pkgs.dprint-plugins.getPluginList (
+          plugins: [plugins.dprint-plugin-markdown]
+        );
       };
     };
     statix.enable = true;

--- a/treefmt.nix
+++ b/treefmt.nix
@@ -4,6 +4,12 @@ _: {
     alejandra.enable = true;
     dprint = {
       enable = true;
+      includes = [
+        "**/*.{astro,html,ts,tsx,js,mjs,cjs,jsx,json,jsonc,toml,yaml,yml,md}"
+        "**/*.{graphql,gql,ipynb,py,pyi}"
+        "Dockerfile"
+      ];
+      excludes = ["node_modules" "*-lock.json" "*-lock.yaml" "dist"];
       settings = {
         incremental = true;
         lineWidth = 80;
@@ -24,12 +30,6 @@ _: {
         markdown.textWrap = "always";
         markup.quotes = "single";
         ruff.lineLength = 80;
-        includes = [
-          "**/*.{astro,html,ts,tsx,js,mjs,cjs,jsx,json,jsonc,toml,yaml,yml,md}"
-          "**/*.{graphql,gql,ipynb,py,pyi}"
-          "Dockerfile"
-        ];
-        excludes = ["node_modules" "*-lock.json" "*-lock.yaml" "dist"];
         # https://plugins.dprint.dev
         plugins = [
           "https://plugins.dprint.dev/typescript-0.95.5.wasm"

--- a/treefmt.nix
+++ b/treefmt.nix
@@ -32,16 +32,16 @@ _: {
         excludes = ["node_modules" "*-lock.json" "*-lock.yaml" "dist"];
         # https://plugins.dprint.dev
         plugins = [
-          "https://plugins.dprint.dev/typescript-0.93.0.wasm"
-          "https://plugins.dprint.dev/json-0.19.3.wasm"
-          "https://plugins.dprint.dev/markdown-0.17.8.wasm"
-          "https://plugins.dprint.dev/toml-0.6.2.wasm"
-          "https://plugins.dprint.dev/dockerfile-0.3.2.wasm"
+          "https://plugins.dprint.dev/typescript-0.95.5.wasm"
+          "https://plugins.dprint.dev/json-0.20.0.wasm"
+          "https://plugins.dprint.dev/markdown-0.18.0.wasm"
+          "https://plugins.dprint.dev/toml-0.7.0.wasm"
+          "https://plugins.dprint.dev/dockerfile-0.3.3.wasm"
           "https://plugins.dprint.dev/ruff-0.3.9.wasm"
-          "https://plugins.dprint.dev/jupyter-0.1.4.wasm"
-          "https://plugins.dprint.dev/g-plane/markup_fmt-v0.12.0.wasm"
-          "https://plugins.dprint.dev/g-plane/pretty_yaml-v0.5.0.wasm"
-          "https://plugins.dprint.dev/g-plane/pretty_graphql-v0.2.0.wasm"
+          "https://plugins.dprint.dev/jupyter-0.2.0.wasm"
+          "https://plugins.dprint.dev/g-plane/markup_fmt-v0.20.0.wasm"
+          "https://plugins.dprint.dev/g-plane/pretty_yaml-v0.5.1.wasm"
+          "https://plugins.dprint.dev/g-plane/pretty_graphql-v0.2.1.wasm"
         ];
       };
     };


### PR DESCRIPTION
## Summary
  - Add dprint code formatter integration with treefmt
  - Configure dprint for markdown files with consistent formatting settings
  - Update flake.nix to include dprint in the development environment

  ## Changes
  - Added dprint configuration in treefmt.nix with markdown plugin
  - Configured formatting settings: 80 character line width, 2 space indentation, LF line endings
  - Updated flake.nix to expose dprint binary
  - Set up markdown text wrapping for consistent documentation formatting